### PR TITLE
fix(asyncapi): add '*' to yaml fileMatch patterns

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -243,9 +243,9 @@
         "asyncapi.json",
         "*.asyncapi.json",
         "asyncapi.yml",
-        ".asyncapi.yml",
+        "*.asyncapi.yml",
         "asyncapi.yaml",
-        ".asyncapi.yaml"
+        "*.asyncapi.yaml"
       ],
       "url": "https://asyncapi.com/schema-store/2.4.0.json",
       "versions": {


### PR DESCRIPTION
This PR fixes the recently added fileMatch patterns for AsyncAPI by adding the `*` prefix to those who didn't have but needed it.